### PR TITLE
StringIO#initialize default to the source string encoding

### DIFF
--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -363,7 +363,12 @@ strio_init(int argc, VALUE *argv, struct StringIO *ptr, VALUE self)
 	rb_str_resize(string, 0);
     }
     ptr->string = string;
-    ptr->enc = convconfig.enc;
+    if (argc == 1) {
+	ptr->enc = rb_enc_get(string);
+    }
+    else {
+	ptr->enc = convconfig.enc;
+    }
     ptr->pos = 0;
     ptr->lineno = 0;
     if (ptr->flags & FMODE_SETENC_BY_BOM) set_encoding_by_bom(ptr);
@@ -1759,9 +1764,6 @@ strio_set_encoding_by_bom(VALUE self)
 {
     struct StringIO *ptr = StringIO(self);
 
-    if (ptr->enc) {
-	rb_raise(rb_eArgError, "encoding conversion is set");
-    }
     if (!set_encoding_by_bom(ptr)) return Qnil;
     return rb_enc_from_encoding(ptr->enc);
 }

--- a/test/stringio/test_stringio.rb
+++ b/test/stringio/test_stringio.rb
@@ -797,6 +797,18 @@ class TestStringIO < Test::Unit::TestCase
     end
   end
 
+  def test_binary_encoding_read_and_default_internal
+    verbose, $VERBOSE = $VERBOSE, nil
+    default_internal = Encoding.default_internal
+    Encoding.default_internal = Encoding::UTF_8
+    $VERBOSE = verbose
+    assert_equal Encoding::BINARY, StringIO.new("Hello".b).read.encoding
+  ensure
+    $VERBOSE = nil
+    Encoding.default_internal = default_internal
+    $VERBOSE = verbose
+  end
+
   def assert_string(content, encoding, str, mesg = nil)
     assert_equal([content, encoding], [str, str.encoding], mesg)
   end


### PR DESCRIPTION
[Bug #16497]