### PR TITLE
Raise an error if encoding conversion not succeeded

### DIFF
--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -1435,7 +1435,12 @@ strio_write(VALUE self, VALUE str)
     enc = get_enc(ptr);
     enc2 = rb_enc_get(str);
     if (enc != enc2 && enc != ascii8bit) {
-	str = rb_str_conv_enc(str, enc2, enc);
+	VALUE converted = rb_str_conv_enc(str, enc2, enc);
+	if (converted == str && enc2 != ascii8bit) { /* conversion failed */
+	    rb_enc_check(rb_enc_from_encoding(enc), str);
+	    UNREACHABLE;
+	}
+	str = converted;
     }
     len = RSTRING_LEN(str);
     if (len == 0) return 0;

--- a/test/stringio/test_stringio.rb
+++ b/test/stringio/test_stringio.rb
@@ -187,6 +187,31 @@ class TestStringIO < Test::Unit::TestCase
     assert_equal(Encoding::UTF_8, s.encoding, "honor the original encoding over ASCII-8BIT")
   end
 
+  def test_write_encoding_conversion
+    convertible = "\u{3042}"
+    inconvertible = "\u{1f363}"
+    conversion_encoding = Encoding::Windows_31J
+
+    s = StringIO.new.set_encoding(conversion_encoding)
+    s.write(convertible)
+    assert_equal(conversion_encoding, s.string.encoding)
+    all_assertions do |a|
+      [
+        inconvertible,
+        convertible + inconvertible,
+        [convertible, inconvertible],
+        ["a", inconvertible],
+      ].each do |data|
+        a.for(data.inspect) do
+          s = StringIO.new.set_encoding(conversion_encoding)
+          assert_raise(Encoding::CompatibilityError) do
+            s.write(*data)
+          end
+        end
+      end
+    end
+  end
+
   def test_write_integer_overflow
     f = StringIO.new
     f.pos = RbConfig::LIMITS["LONG_MAX"]


### PR DESCRIPTION
As `rb_str_conv_enc()` returns the argument string object itself unchanged when any conversion failed, check the incompatibility in that case.

Fixes https://github.com/ruby/stringio/issues/13