### PR TITLE
CI: use setup-ruby bundler-cache

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,7 +19,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Install dependencies
-      run: bundle install
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run test
-      run: rake
+      run: bundle exec rake

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -19,7 +19,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Install dependencies
-      run: bundle install
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run test
       run: rake

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -21,4 +21,4 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run test
-      run: rake
+      run: bundle exec rake

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,8 +18,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Install dependencies
-      run: bundle install
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run test
-      run: rake
+      run: bundle exec rake
 


### PR DESCRIPTION
⚠️ Me, learning if it is possible to use the bundler-cache option of setup-ruby. ⚠️ 

This option makes the Action install the gems in the setup-ruby-provided step.