### PR TITLE
Ignore chomp keyword for nil separator

### DIFF
--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -1127,6 +1127,7 @@ prepare_getline_args(struct getline_arg *arg, int argc, VALUE *argv)
     long limit = -1;
 
     argc = rb_scan_args(argc, argv, "02:", &str, &lim, &opts);
+    int respect_chomp = argc == 0 || !NIL_P(str);
     switch (argc) {
       case 0:
 	str = rb_rs;
@@ -1160,7 +1161,9 @@ prepare_getline_args(struct getline_arg *arg, int argc, VALUE *argv)
 	    keywords[0] = rb_intern_const("chomp");
 	}
 	rb_get_kwargs(opts, keywords, 0, 1, &vchomp);
-	arg->chomp = (vchomp != Qundef) && RTEST(vchomp);
+        if (respect_chomp) {
+	    arg->chomp = (vchomp != Qundef) && RTEST(vchomp);
+        }
     }
     return arg;
 }

--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -1125,9 +1125,10 @@ prepare_getline_args(struct getline_arg *arg, int argc, VALUE *argv)
 {
     VALUE str, lim, opts;
     long limit = -1;
+    int respect_chomp;
 
     argc = rb_scan_args(argc, argv, "02:", &str, &lim, &opts);
-    int respect_chomp = argc == 0 || !NIL_P(str);
+    respect_chomp = argc == 0 || !NIL_P(str);
     switch (argc) {
       case 0:
 	str = rb_rs;

--- a/test/stringio/test_stringio.rb
+++ b/test/stringio/test_stringio.rb
@@ -92,7 +92,7 @@ class TestStringIO < Test::Unit::TestCase
     assert_equal("a", StringIO.new("a").gets(chomp: true))
     assert_equal("a", StringIO.new("a\nb").gets(chomp: true))
     assert_equal("abc", StringIO.new("abc\n\ndef\n").gets(chomp: true))
-    assert_equal("abc\n\ndef", StringIO.new("abc\n\ndef\n").gets(nil, chomp: true))
+    assert_equal("abc\n\ndef\n", StringIO.new("abc\n\ndef\n").gets(nil, chomp: true))
     assert_equal("abc\n", StringIO.new("abc\n\ndef\n").gets("", chomp: true))
     stringio = StringIO.new("abc\n\ndef\n")
     assert_equal("abc\n", stringio.gets("", chomp: true))
@@ -109,7 +109,7 @@ class TestStringIO < Test::Unit::TestCase
     assert_equal("a", StringIO.new("a").gets(chomp: true))
     assert_equal("a", StringIO.new("a\r\nb").gets(chomp: true))
     assert_equal("abc", StringIO.new("abc\r\n\r\ndef\r\n").gets(chomp: true))
-    assert_equal("abc\r\n\r\ndef", StringIO.new("abc\r\n\r\ndef\r\n").gets(nil, chomp: true))
+    assert_equal("abc\r\n\r\ndef\r\n", StringIO.new("abc\r\n\r\ndef\r\n").gets(nil, chomp: true))
     assert_equal("abc\r\n", StringIO.new("abc\r\n\r\ndef\r\n").gets("", chomp: true))
     stringio = StringIO.new("abc\r\n\r\ndef\r\n")
     assert_equal("abc\r\n", stringio.gets("", chomp: true))
@@ -598,6 +598,9 @@ class TestStringIO < Test::Unit::TestCase
     assert_equal(["foo\r\nbar\r\n\r\n", "baz\r\n"], f.each("").to_a)
     f.rewind
     assert_equal(["foo\r\nbar\r\n", "baz"], f.each("", chomp: true).to_a)
+
+    f = StringIO.new("abc\n\ndef\n")
+    assert_equal(["ab", "c\n", "\nd", "ef", "\n"], f.each(nil, 2, chomp: true).to_a)
   end
 
   def test_putc


### PR DESCRIPTION
nil separator means no separator at all, so nothing should be
chomped.

Partial fix for Ruby [Bug #18770]