### PR TITLE
Add note about #to_io and remove mentions of the bin/ dir from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This library is based on MoonWolf version written in Ruby.  Thanks a lot.
 
 * `fileno` raises `NotImplementedError`.
 * encoding conversion is not implemented, and ignored silently.
-* there is no`#to_io` method
+* there is no `#to_io` method because this is not an `IO.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Or install it yourself as:
 
 ## Development
 
-Run `rake test` to run the tests. 
+Run `bundle install` to install dependencies and then `rake test` to run the tests. 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This library is based on MoonWolf version written in Ruby.  Thanks a lot.
 
 * `fileno` raises `NotImplementedError`.
 * encoding conversion is not implemented, and ignored silently.
+* there is no`#to_io` method
 
 ## Installation
 
@@ -31,7 +32,7 @@ Or install it yourself as:
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+Run `rake test` to run the tests. 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Or install it yourself as:
 
 ## Development
 
-Run `bundle install` to install dependencies and then `rake test` to run the tests. 
+Run `bundle install` to install dependencies and then `bundle exec rake test` to run the tests. 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 


### PR DESCRIPTION
Add a missing `#to_io` note. See also: #40

There is no `bin` directory in the repository, so mentioning it in the README is misleading. I was able to run `rake test` after installing dependencies with `bundler installs`, so I assume we could change the README.
