### PR TITLE
PoC of simple StringIO#to_io

### DIFF
--- a/ext/java/org/jruby/ext/stringio/StringIO.java
+++ b/ext/java/org/jruby/ext/stringio/StringIO.java
@@ -1294,6 +1294,11 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
         return each_codepoint(context, block);
     }
 
+    @JRubyMethod(name = "to_io")
+    public IRubyObject to_io() {
+    	return this;
+    }
+
     public static class GenericReadable {
         @JRubyMethod(name = "readchar")
         public static IRubyObject readchar(ThreadContext context, IRubyObject self) {

--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -1151,6 +1151,12 @@ strio_each_char(VALUE self)
     return self;
 }
 
+static VALUE
+strio_to_io(VALUE io)
+{
+    return io;
+}
+
 /*
  * call-seq:
  *   each_codepoint {|codepoint| ... } -> self
@@ -1915,6 +1921,7 @@ Init_stringio(void)
     rb_define_method(StringIO, "each_line", strio_each, -1);
     rb_define_method(StringIO, "each_byte", strio_each_byte, 0);
     rb_define_method(StringIO, "each_char", strio_each_char, 0);
+    rb_define_method(StringIO, "to_io", strio_to_io, 0);
     rb_define_method(StringIO, "each_codepoint", strio_each_codepoint, 0);
     rb_define_method(StringIO, "getc", strio_getc, 0);
     rb_define_method(StringIO, "ungetc", strio_ungetc, 1);

--- a/test/stringio/test_stringio.rb
+++ b/test/stringio/test_stringio.rb
@@ -913,6 +913,11 @@ class TestStringIO < Test::Unit::TestCase
     $VERBOSE = verbose
   end
 
+  def test_to_io
+    s = StringIO.new("abc")
+    assert_equal(s.to_io, s)
+  end
+
   def assert_string(content, encoding, str, mesg = nil)
     assert_equal([content, encoding], [str, str.encoding], mesg)
   end


### PR DESCRIPTION
I've implemented the simplest `StringIO#to_io` possible: returning self. The actual implementations are mostly taken from `IO` class.

After I did this, I started looking for an open ticket for it (I was sure it was somewhere in the redmine), but instead I found that this feature has been already rejected 3 (!) times:
* https://bugs.ruby-lang.org/issues/7873
* https://bugs.ruby-lang.org/issues/5678
* https://bugs.ruby-lang.org/issues/5479

I'm putting it on GH for future reference, with no intention of merging it.
