### PR TITLE
Support encoding keyword in initialize (JRuby)

### DIFF
--- a/ext/java/org/jruby/ext/stringio/StringIO.java
+++ b/ext/java/org/jruby/ext/stringio/StringIO.java
@@ -156,7 +156,19 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
         StringIOData ptr = this.ptr;
 
         synchronized (ptr) {
-            switch (args.length) {
+            int argc = args.length;
+            Encoding encoding = null;
+
+            IRubyObject options = ArgsUtil.getOptionsArg(runtime, args);
+            if (!options.isNil()) {
+                argc--;
+                IRubyObject encodingOpt = ArgsUtil.extractKeywordArg(context, "encoding", (RubyHash) options);
+                if (!encodingOpt.isNil()) {
+                    encoding = EncodingUtils.toEncoding(context, encodingOpt);
+                }
+            }
+
+            switch (argc) {
                 case 2:
                     mode = args[1];
                     final boolean trunc;
@@ -190,7 +202,7 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
             }
 
             ptr.string = string;
-            ptr.enc = null;
+            ptr.enc = encoding;
             ptr.pos = 0;
             ptr.lineno = 0;
             // funky way of shifting readwrite flags into object flags


### PR DESCRIPTION
This PR will add support for the `encoding` keyword to `initialize` in the JRuby extension.

Unfortunately there appears to be no tests for this behavior, so adding some may have to be part of this work.