### PR TITLE
Update write-barrier at copying

### DIFF
--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -698,15 +698,19 @@ strio_eof(VALUE self)
 static VALUE
 strio_copy(VALUE copy, VALUE orig)
 {
-    struct StringIO *ptr;
+    struct StringIO *ptr, *old_ptr;
+    VALUE old_string = Qundef;
 
     orig = rb_convert_type(orig, T_DATA, "StringIO", "to_strio");
     if (copy == orig) return copy;
     ptr = StringIO(orig);
-    if (check_strio(copy)) {
-	strio_free(DATA_PTR(copy));
+    old_ptr = check_strio(copy);
+    if (old_ptr) {
+	old_string = old_ptr->string;
+	strio_free(old_ptr);
     }
     DATA_PTR(copy) = ptr;
+    RB_OBJ_WRITTEN(copy, old_string, ptr->string);
     RBASIC(copy)->flags &= ~STRIO_READWRITE;
     RBASIC(copy)->flags |= RBASIC(orig)->flags & STRIO_READWRITE;
     ++ptr->count;


### PR DESCRIPTION
http://ci.rvm.jp/results/trunk-asserts@ruby-sp2-docker/4552803

```
verify_internal_consistency_reachable_i: WB miss (O->Y) 0x00007f752ddd5550 [3LM    ] strio (StringIO)strio -> 0x00007f752d19b7d0 [0      ] T_STRING (String) len: 8, capa: 15 "to_strio"
<internal:/tmp/ruby/src/trunk-asserts/lib/rubygems/core_ext/kernel_require.rb>:53: [BUG] gc_verify_internal_consistency: found internal inconsistency.
```