### PR TITLE
Add version.rb and load it from stringio.rb

### DIFF
--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -12,8 +12,6 @@
 
 **********************************************************************/
 
-#define STRINGIO_VERSION "3.0.8"
-
 #include "ruby.h"
 #include "ruby/io.h"
 #include "ruby/encoding.h"
@@ -1831,8 +1829,6 @@ Init_stringio(void)
 #endif
 
     VALUE StringIO = rb_define_class("StringIO", rb_cObject);
-
-    rb_define_const(StringIO, "VERSION", rb_str_new_cstr(STRINGIO_VERSION));
 
     rb_include_module(StringIO, rb_mEnumerable);
     rb_define_alloc_func(StringIO, strio_s_allocate);

--- a/lib/stringio.rb
+++ b/lib/stringio.rb
@@ -4,3 +4,5 @@ if RUBY_ENGINE == 'jruby'
 else
   require 'stringio.so'
 end
+
+require 'stringio/version'

--- a/lib/stringio/version.rb
+++ b/lib/stringio/version.rb
@@ -1,3 +1,3 @@
 class StringIO
-  VERSION = "3.0.6"
+  VERSION = "3.0.8"
 end

--- a/lib/stringio/version.rb
+++ b/lib/stringio/version.rb
@@ -1,0 +1,3 @@
+class StringIO
+  VERSION = "3.0.6"
+end

--- a/rakelib/version.rake
+++ b/rakelib/version.rake
@@ -1,10 +1,10 @@
 class << (helper = Bundler::GemHelper.instance)
-  SOURCE_PATH = "ext/stringio/stringio.c"
+  SOURCE_PATH = "lib/stringio/version.rb"
   def update_source_version
     path = SOURCE_PATH
     File.open(path, "r+b") do |f|
       d = f.read
-      if d.sub!(/^#define\s+STRINGIO_VERSION\s+\K".*"/) {version.to_s.dump}
+      if d.sub!(/^\s+VERSION\s+=\s+\K".*"/) {version.to_s.dump}
         f.rewind
         f.truncate(0)
         f.print(d)

--- a/stringio.gemspec
+++ b/stringio.gemspec
@@ -1,15 +1,10 @@
 # -*- coding: utf-8 -*-
 # frozen_string_literal: true
 
-source_version = ["", "ext/stringio/"].find do |dir|
-  begin
-    break File.open(File.join(__dir__, "#{dir}stringio.c")) {|f|
-      f.gets("\n#define STRINGIO_VERSION ")
-      f.gets[/\s*"(.+)"/, 1]
-    }
-  rescue Errno::ENOENT
-  end
-end
+source_version = File.open("lib/stringio/version.rb") {|f|
+  f.gets("\n  VERSION = ")
+  f.gets[/\s*"(.+)"/, 1]
+}
 Gem::Specification.new do |s|
   s.name = "stringio"
   s.version = source_version
@@ -18,10 +13,10 @@ Gem::Specification.new do |s|
   s.authors = ["Nobu Nakada", "Charles Oliver Nutter"]
   s.description = "Pseudo `IO` class from/to `String`."
   s.email = ["nobu@ruby-lang.org", "headius@headius.com"]
-  s.files = ["README.md"]
+  s.files = ["README.md", "lib/stringio.rb", "lib/stringio/version.rb"]
   jruby = true if Gem::Platform.new('java') =~ s.platform or RUBY_ENGINE == 'jruby'
   if jruby
-    s.files += ["lib/stringio.rb", "lib/stringio.jar"]
+    s.files += ["lib/stringio.jar"]
     s.platform = "java"
   else
     s.extensions = ["ext/stringio/extconf.rb"]


### PR DESCRIPTION
Fixes #57

This probably will need some discussion. There are no shared .rb files between the C extension gem and the JRuby extension gem. There's no easy way to inject a value into the javac compilation, so it seemed like the best answer is to move the version to a common `stringio/version.rb` file and start shipping the `stringio.rb` that loads correctly for JRuby or non-JRuby.

I am open to suggestions on a better way to solve this without having the version string in more than one place.