### PR TITLE
Do not compile the C extension on TruffleRuby

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,8 @@ require "rake/testtask"
 
 name = "stringio"
 
-if RUBY_PLATFORM =~ /java/
+case RUBY_ENGINE
+when "jruby"
   require 'rake/javaextensiontask'
   extask = Rake::JavaExtensionTask.new("stringio") do |ext|
     ext.lib_dir << "/#{ext.platform}"
@@ -13,15 +14,22 @@ if RUBY_PLATFORM =~ /java/
   end
 
   task :build => "#{extask.lib_dir}/#{extask.name}.jar"
-else
+when "ruby"
   require 'rake/extensiontask'
   extask = Rake::ExtensionTask.new(name) do |x|
     x.lib_dir << "/#{RUBY_VERSION}/#{x.platform}"
   end
+else
+  task :compile
 end
+
 Rake::TestTask.new(:test) do |t|
-  ENV["RUBYOPT"] = "-I" + [extask.lib_dir, "test/lib"].join(File::PATH_SEPARATOR)
-  t.libs << extask.lib_dir
+  if extask
+    ENV["RUBYOPT"] = "-I" + [extask.lib_dir, "test/lib"].join(File::PATH_SEPARATOR)
+    t.libs << extask.lib_dir
+  else
+    ENV["RUBYOPT"] = "-Itest/lib"
+  end
   t.libs << "test/lib"
   t.ruby_opts << "-rhelper"
   t.test_files = FileList["test/**/test_*.rb"]

--- a/ext/stringio/extconf.rb
+++ b/ext/stringio/extconf.rb
@@ -1,3 +1,7 @@
 # frozen_string_literal: false
 require 'mkmf'
-create_makefile('stringio')
+if RUBY_ENGINE == 'ruby'
+  create_makefile('stringio')
+else
+  File.write('Makefile', dummy_makefile("").join)
+end


### PR DESCRIPTION
* Before this it was compiled but not used, because TruffleRuby has a stringio.rb in stdlib and .rb has precedence over .so. In fact that extension never worked on TruffleRuby, because rb_io_extract_modeenc() has never been defined on TruffleRuby.
* So this just skips compiling the extension since compilation of it now fails: https://github.com/ruby/openssl/issues/699

The approach is similar to the one in [strscan](https://github.com/ruby/strscan/pull/35/files), notably:
> Write conditions in a way that any other Ruby implementation would
simply use its stdlib until it is added explicit support in this gem.

TruffleRuby is not added in CI because there are quite a few failures:
```
89 tests, 508 assertions, 22 failures, 7 errors, 0 pendings, 1 omissions, 0 notifications
67.0455% passed
```
It makes more sense to fix https://github.com/oracle/truffleruby/blob/master/lib/truffle/stringio.rb to pass more of the tests before adding TruffleRuby to the CI.

Note that `gem install stringio` and any `Gemfile` transitively including `stringio` is broken on truffleruby-dev until this is merged and released.
So it would be awesome if we could have a quick release of `stringio` with this fix.
