### PR TITLE
Update the coderange after overwrite

### DIFF
--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -1464,8 +1464,14 @@ strio_write(VALUE self, VALUE str)
 	}
     }
     else {
+	int cr0 = ENC_CODERANGE(ptr->string);
+	int cr = ENC_CODERANGE_UNKNOWN;
+	if (rb_enc_asciicompat(enc) && rb_enc_asciicompat(enc2)) {
+	    cr = ENC_CODERANGE_AND(cr0, ENC_CODERANGE(str));
+	}
 	strio_extend(ptr, ptr->pos, len);
 	memmove(RSTRING_PTR(ptr->string)+ptr->pos, RSTRING_PTR(str), len);
+	if (cr != cr0) ENC_CODERANGE_SET(ptr->string, cr);
     }
     RB_GC_GUARD(str);
     ptr->pos += len;

--- a/test/stringio/test_stringio.rb
+++ b/test/stringio/test_stringio.rb
@@ -953,6 +953,16 @@ class TestStringIO < Test::Unit::TestCase
     $VERBOSE = verbose
   end
 
+  def test_coderange_after_overwrite
+    s = StringIO.new("".b)
+
+    s.write("a=b&c=d")
+    s.rewind
+    assert_predicate(s.string, :ascii_only?)
+    s.write "\u{431 43e 433 443 441}"
+    assert_not_predicate(s.string, :ascii_only?)
+  end
+
   def assert_string(content, encoding, str, mesg = nil)
     assert_equal([content, encoding], [str, str.encoding], mesg)
   end


### PR DESCRIPTION
Fix https://bugs.ruby-lang.org/issues/20185