### PR TITLE
Use macos-arm-oss(=macos-13) and macos-12 runners instead of macos-11

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,7 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - macos-11.0
+        - macos-12
+        - macos-arm-oss
         ruby: [ '2.7', '3.0', '3.1', '3.2', 'debug', 'head' ]
     steps:
     - uses: actions/checkout@v4
@@ -25,7 +26,7 @@ jobs:
       run: bundle exec rake build
     - uses: actions/upload-artifact@v4
       if: >-
-        matrix.os == 'macos-11.0' &&
+        matrix.os == 'macos-12' &&
           matrix.ruby == '3.2'
       with:
         name: gem-${{ matrix.os }}-${{ matrix.ruby }}


### PR DESCRIPTION
This is same as https://github.com/ruby/fiddle/pull/137