### PR TITLE
Use new name for cat19

### DIFF
--- a/ext/java/org/jruby/ext/stringio/StringIO.java
+++ b/ext/java/org/jruby/ext/stringio/StringIO.java
@@ -1299,7 +1299,7 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
                 if (enc == EncodingUtils.ascii8bitEncoding(runtime) || encStr == EncodingUtils.ascii8bitEncoding(runtime)) {
                     EncodingUtils.encStrBufCat(runtime, ptr.string, strByteList, enc);
                 } else {
-                    ptr.string.cat19(str);
+                    ptr.string.catWithCodeRange(str);
                 }
             } else {
                 strioExtend(ptr.pos, len);


### PR DESCRIPTION
This cannot be merged until JRuby has released a version that supports it, and should not be released until we have decided how to transition away from older JRuby versions that do not have this name.

See https://github.com/ruby/stringio/issues/83