### PR TITLE
Various cleanup for JRuby ext

### DIFF
--- a/ext/java/org/jruby/ext/stringio/StringIO.java
+++ b/ext/java/org/jruby/ext/stringio/StringIO.java
@@ -436,13 +436,7 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
         }
     }
 
-    @JRubyMethod(name = "lines", optional = 2)
-    public IRubyObject lines(ThreadContext context, IRubyObject[] args, Block block) {
-        context.runtime.getWarnings().warn("StringIO#lines is deprecated; use #each_line instead");
-        return block.isGiven() ? each(context, args, block) : enumeratorize(context.runtime, this, "each_line", args);
-    }
-
-    @JRubyMethod(name = {"each_byte", "bytes"})
+    @JRubyMethod(name = {"each_byte"})
     public IRubyObject each_byte(ThreadContext context, Block block) {
         Ruby runtime = context.runtime;
 
@@ -476,13 +470,6 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
             block.yieldSpecific(context, c);
         }
         return this;
-    }
-
-    @JRubyMethod
-    public IRubyObject chars(final ThreadContext context, final Block block) {
-        context.runtime.getWarnings().warn("StringIO#chars is deprecated; use #each_char instead");
-
-        return each_char(context, block);
     }
 
     @JRubyMethod(name = {"eof", "eof?"})
@@ -1472,16 +1459,6 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
         } finally {
             unlock(ptr);
         }
-    }
-
-    @JRubyMethod(name = "codepoints")
-    public IRubyObject codepoints(ThreadContext context, Block block) {
-        Ruby runtime = context.runtime;
-        runtime.getWarnings().warn("StringIO#codepoints is deprecated; use #each_codepoint");
-
-        if (!block.isGiven()) return enumeratorize(runtime, this, "each_codepoint");
-
-        return each_codepoint(context, block);
     }
 
     public static class GenericReadable {

--- a/ext/java/org/jruby/ext/stringio/StringIO.java
+++ b/ext/java/org/jruby/ext/stringio/StringIO.java
@@ -259,7 +259,7 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
         return this;
     }
 
-    @JRubyMethod(name = {"fcntl"}, rest = true)
+    @JRubyMethod(name = {"fcntl"}, rest = true, notImplemented = true)
     public IRubyObject strio_unimpl(ThreadContext context, IRubyObject[] args) {
         throw context.runtime.newNotImplementedError("");
     }

--- a/test/stringio/test_stringio.rb
+++ b/test/stringio/test_stringio.rb
@@ -237,8 +237,9 @@ class TestStringIO < Test::Unit::TestCase
 
   def test_write_integer_overflow
     f = StringIO.new
-    f.pos = RbConfig::LIMITS["LONG_MAX"]
     assert_raise(ArgumentError) {
+      # JRuby errors when setting pos to an out-of-range value
+      f.pos = RbConfig::LIMITS["LONG_MAX"]
       f.write("pos + len overflows")
     }
   end


### PR DESCRIPTION
* Fix compile warnings on latest Java.
* Adjust one test for JRuby erroring on bad pos= value.
* Replace hard JVM synchronization with a spin lock.
* Avoid duplicate reads of state fields where possible.
* Remove long-deprecated codepoints, chars, bytes, lines methods.
* Mark fcntl as not implemented
* Split most of the remaining variable-arity methods.