### PR TITLE
Print a deprecation warning for chilled strings

### DIFF
--- a/test/stringio/test_stringio.rb
+++ b/test/stringio/test_stringio.rb
@@ -882,6 +882,24 @@ class TestStringIO < Test::Unit::TestCase
     assert_raise(IOError, bug) {s.ungetbyte("a")}
   end
 
+  def test_chilled_string
+    s = eval("StringIO.new('')")
+    assert_predicate(s.string, :frozen?)
+
+    assert_deprecated_warning(/literal string will be frozen in the future/) do
+      s.write("abc")
+    end
+    refute_predicate(s.string, :frozen?)
+
+    eval("s.string = 'foo'")
+
+    assert_predicate(s.string, :frozen?)
+    assert_deprecated_warning(/literal string will be frozen in the future/) do
+      s.write("bar")
+    end
+    refute_predicate(s.string, :frozen?)
+  end if RUBY_VERSION >= "3.4"
+
   def test_readlines_limit_0
     assert_raise(ArgumentError, "[ruby-dev:43392]") { StringIO.new.readlines(0) }
   end


### PR DESCRIPTION
https://github.com/ruby/ruby/pull/10262#issuecomment-2015041240

As far as I can tell, since this isn't exposed there is no good way to actually get this information "officially". I'm not very familiar with programming ruby itself and even less familiar with C.

If there is a better way to do this, feel free to take over.

cc @casperisfine 