### PR TITLE
Eagerly defrost chilled strings

### DIFF
--- a/lib/stringio.rb
+++ b/lib/stringio.rb
@@ -1,0 +1,19 @@
+require "stringio.so"
+
+if "test".frozen? && !"test".equal?("test") # Ruby 3.4+ chilled strings
+  class StringIO
+    alias_method :_initialize, :initialize
+    private :_initialize
+
+    def initialize(*args, **kwargs)
+      string = args.first
+      if string && string.frozen?
+        begin
+          string << "" # Eagerly defrost the string
+        rescue FrozenError
+        end
+      end
+      _initialize(*args, **kwargs)
+    end
+  end
+end

--- a/test/stringio/test_stringio.rb
+++ b/test/stringio/test_stringio.rb
@@ -981,4 +981,12 @@ class TestStringIO < Test::Unit::TestCase
   def assert_string(content, encoding, str, mesg = nil)
     assert_equal([content, encoding], [str, str.encoding], mesg)
   end
+
+  if eval(%{ "test".frozen? && !"test".equal?("test") }) # Ruby 3.4+ chilled strings
+    def test_chilled_string
+      io = eval(%{ StringIO.new("") })
+      io << "test"
+      assert_equal("test", io.string)
+    end
+  end
 end


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/20205
Fix: https://github.com/ruby/stringio/pull/92

One minor backward compatibility issue with chilled strings is that since they claim to be frozen, code using the pattern:

```ruby
StringIO.new("")
```

Is now producing read only `StringIO` instances. It would be preferable to emit a warning instead.

We can detect whether the current Ruby produce chilled strings and if so preemptively attempt to mutate the given string to produce the warning immediately and preserve the original behavior.

cc @nobu