### PR TITLE
strio_read: preserve buffer encoding on partial reads

### DIFF
--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -1623,10 +1623,9 @@ strio_read(int argc, VALUE *argv, VALUE self)
 	if (len > rest) len = rest;
 	rb_str_resize(str, len);
 	MEMCPY(RSTRING_PTR(str), RSTRING_PTR(ptr->string) + ptr->pos, char, len);
-	if (binary)
-	    rb_enc_associate(str, rb_ascii8bit_encoding());
-	else
+	if (!binary) {
 	    rb_enc_copy(str, ptr->string);
+	}
     }
     ptr->pos += RSTRING_LEN(str);
     return str;

--- a/test/stringio/test_stringio.rb
+++ b/test/stringio/test_stringio.rb
@@ -700,6 +700,18 @@ class TestStringIO < Test::Unit::TestCase
     s.force_encoding(Encoding::US_ASCII)
     assert_same(s, f.read(nil, s))
     assert_string("", Encoding::UTF_8, s, bug13806)
+
+    bug20418 = '[Bug #20418] ™€®'.b
+    f = StringIO.new(bug20418)
+    s = ""
+    assert_equal(Encoding::UTF_8, s.encoding, bug20418)
+    f.read(4, s)
+    assert_equal(Encoding::UTF_8, s.encoding, bug20418)
+
+    f.rewind
+    s = ""
+    f.read(nil, s)
+    assert_equal(Encoding::ASCII_8BIT, s.encoding, bug20418)
   end
 
   def test_readpartial
@@ -711,8 +723,8 @@ class TestStringIO < Test::Unit::TestCase
     assert_equal("\u3042\u3044".force_encoding(Encoding::ASCII_8BIT), f.readpartial(f.size))
     f.rewind
     # not empty buffer
-    s = '0123456789'
-    assert_equal("\u3042\u3044".force_encoding(Encoding::ASCII_8BIT), f.readpartial(f.size, s))
+    s = '0123456789'.b
+    assert_equal("\u3042\u3044".b, f.readpartial(f.size, s))
   end
 
   def test_read_nonblock
@@ -736,8 +748,8 @@ class TestStringIO < Test::Unit::TestCase
     assert_equal("\u3042\u3044".force_encoding(Encoding::ASCII_8BIT), f.read_nonblock(f.size))
     f.rewind
     # not empty buffer
-    s = '0123456789'
-    assert_equal("\u3042\u3044".force_encoding(Encoding::ASCII_8BIT), f.read_nonblock(f.size, s))
+    s = '0123456789'.b
+    assert_equal("\u3042\u3044".b, f.read_nonblock(f.size, s))
   end
 
   def test_sysread


### PR DESCRIPTION
[[Bug #20418]](https://bugs.ruby-lang.org/issues/20418)

Ruby IO#read preserves the encoding on partial read, but change it when reading the whole IO

from commit ruby/ruby@0ca7036682dad1caea4e7a4fe8fd908d94c878e8:
> * io.c (read_all): should associate default external encoding.
> * io.c (io_read): should NOT associate default external encoding.

cc @nobu 