### PR TITLE
Remove special handling of chilled strings

### DIFF
--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -51,18 +51,11 @@ static long strio_write(VALUE self, VALUE str);
 #define IS_STRIO(obj) (rb_typeddata_is_kind_of((obj), &strio_data_type))
 #define error_inval(msg) (rb_syserr_fail(EINVAL, msg))
 #define get_enc(ptr) ((ptr)->enc ? (ptr)->enc : !NIL_P((ptr)->string) ? rb_enc_get((ptr)->string) : NULL)
-#ifndef HAVE_RB_STR_CHILLED_P
-static bool
-rb_str_chilled_p(VALUE str)
-{
-    return false;
-}
-#endif
 
 static bool
 readonly_string_p(VALUE string)
 {
-    return OBJ_FROZEN_RAW(string) && !rb_str_chilled_p(string);
+    return OBJ_FROZEN_RAW(string);
 }
 
 static struct StringIO *
@@ -183,9 +176,6 @@ check_modifiable(struct StringIO *ptr)
 {
     if (NIL_P(ptr->string)) {
 	/* Null device StringIO */
-    }
-    else if (rb_str_chilled_p(ptr->string)) {
-	rb_str_modify(ptr->string);
     }
     else if (OBJ_FROZEN_RAW(ptr->string)) {
 	rb_raise(rb_eIOError, "not modifiable string");

--- a/test/stringio/test_stringio.rb
+++ b/test/stringio/test_stringio.rb
@@ -990,7 +990,8 @@ class TestStringIO < Test::Unit::TestCase
     assert_predicate(s.string, :ascii_only?)
   end
 
-  if eval(%{ "test".frozen? && !"test".equal?("test") }) # Ruby 3.4+ chilled strings
+  require "objspace"
+  if ObjectSpace.respond_to?(:dump) && ObjectSpace.dump(eval(%{"test"})).include?('"chilled":true') # Ruby 3.4+ chilled strings
     def test_chilled_string
       chilled_string = eval(%{""})
       io = StringIO.new(chilled_string)


### PR DESCRIPTION
[[Feature #20205]](https://bugs.ruby-lang.org/issues/20205)

Followup: https://github.com/ruby/stringio/pull/94

They no longer need to be special cases. If StringIO end up mutating a chilled string, a warning will be emitted.