### PR TITLE
Alias #string to #to_s/#to_str

### DIFF
--- a/ext/java/org/jruby/ext/stringio/StringIO.java
+++ b/ext/java/org/jruby/ext/stringio/StringIO.java
@@ -1311,16 +1311,8 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
         }
     }
 
-    @JRubyMethod(name = "string")
+    @JRubyMethod(name = { "string", "to_s" })
     public IRubyObject string(ThreadContext context) {
-        RubyString string = ptr.string;
-        if (string == null) return context.nil;
-
-        return string;
-    }
-
-    @JRubyMethod(name = "to_s")
-    public IRubyObject to_s(ThreadContext context) {
         RubyString string = ptr.string;
         if (string == null) return context.nil;
 

--- a/ext/java/org/jruby/ext/stringio/StringIO.java
+++ b/ext/java/org/jruby/ext/stringio/StringIO.java
@@ -1319,6 +1319,14 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
         return string;
     }
 
+    @JRubyMethod(name = "to_s")
+    public IRubyObject to_s(ThreadContext context) {
+        RubyString string = ptr.string;
+        if (string == null) return context.nil;
+
+        return string;
+    }
+
     @JRubyMethod(name = "sync")
     public IRubyObject sync(ThreadContext context) {
         checkInitialized();

--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -1910,6 +1910,7 @@ Init_stringio(void)
     rb_define_method(StringIO, "reopen", strio_reopen, -1);
 
     rb_define_method(StringIO, "string", strio_get_string, 0);
+    rb_define_method(StringIO, "to_s", strio_get_string, 0);
     rb_define_method(StringIO, "string=", strio_set_string, 1);
     rb_define_method(StringIO, "lineno", strio_get_lineno, 0);
     rb_define_method(StringIO, "lineno=", strio_set_lineno, 1);

--- a/test/stringio/test_stringio.rb
+++ b/test/stringio/test_stringio.rb
@@ -1010,6 +1010,28 @@ class TestStringIO < Test::Unit::TestCase
     end
   end
 
+  def test_to_s
+    content = "Hello, StringIO!"
+    stringio = StringIO.new(content)
+
+    assert_equal content, stringio.to_s
+    assert_equal content, stringio.string
+    assert_equal stringio.string, stringio.to_s
+
+    stringio.pos = 7
+    assert_equal content, stringio.to_s
+
+    stringio.close
+    assert_equal content, stringio.to_s
+
+    empty_stringio = StringIO.new
+    assert_equal "", empty_stringio.to_s
+
+    stringio_with_encoding = StringIO.new(content.encode("UTF-16LE"))
+    assert_equal content.encode("UTF-16LE"), stringio_with_encoding.to_s
+    assert_equal "UTF-16LE", stringio_with_encoding.to_s.encoding.name
+  end
+
   private
 
   def assert_string(content, encoding, str, mesg = nil)

--- a/test/stringio/test_stringio.rb
+++ b/test/stringio/test_stringio.rb
@@ -1032,6 +1032,32 @@ class TestStringIO < Test::Unit::TestCase
     assert_equal "UTF-16LE", stringio_with_encoding.to_s.encoding.name
   end
 
+  def test_to_s_with_interpolation
+    content = "Hello, StringIO!"
+    stringio = StringIO.new(content)
+
+    assert_equal "Content: #{content}", "Content: #{stringio}"
+
+    assert_equal "Before #{content} After", "Before #{stringio} After"
+
+    empty_stringio = StringIO.new
+    assert_equal "Empty: ", "Empty: #{empty_stringio}"
+
+    utf16_content = content.encode("UTF-16LE")
+    stringio_with_encoding = StringIO.new(utf16_content)
+    assert_equal "UTF-16LE: #{utf16_content.encode('UTF-8')}", "UTF-16LE: #{stringio_with_encoding.to_s.encode('UTF-8')}"
+
+    assert_equal "UTF-16LE", stringio_with_encoding.to_s.encoding.name
+
+    stringio.pos = 7
+    assert_equal "Moved: #{content}", "Moved: #{stringio}"
+
+    stringio.close
+    assert_equal "Closed: #{content}", "Closed: #{stringio}"
+
+    assert_equal "Start #{content} Middle #{empty_stringio} End", "Start #{stringio} Middle #{empty_stringio} End"
+  end
+
   private
 
   def assert_string(content, encoding, str, mesg = nil)


### PR DESCRIPTION
fix GH-102

imo, a lot of users would rather call `buffer.to_s` instead of the .string method, nobody atm depends on the `.to_s`. There already is .inspect that behaves like the current to_s

bonus, having `.to_s`, now you can interpolate string io into strings w/o calling .to_s

