### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/stringio

### DIFF
--- a/stringio.gemspec
+++ b/stringio.gemspec
@@ -39,6 +39,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.7"
   s.summary = "Pseudo IO on String"
 
+  s.metadata["changelog_uri"] = s.homepage + "/blob/master/NEWS.md"
+
   # s.cert_chain  = %w[certs/nobu.pem]
   # s.signing_key = File.expand_path("~/.ssh/gem-private_key.pem") if $0 =~ /gem\z/
 end

--- a/stringio.gemspec
+++ b/stringio.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.7"
   s.summary = "Pseudo IO on String"
 
-  s.metadata["changelog_uri"] = s.homepage + "/blob/master/NEWS.md"
+  s.metadata["changelog_uri"] = "#{s.homepage}/releases/tag/v#{s.version}"
 
   # s.cert_chain  = %w[certs/nobu.pem]
   # s.signing_key = File.expand_path("~/.ssh/gem-private_key.pem") if $0 =~ /gem\z/


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/stringio which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/#metadata