### PR TITLE
Use private lookup for these handles

### DIFF
--- a/ext/java/org/jruby/ext/stringio/StringIO.java
+++ b/ext/java/org/jruby/ext/stringio/StringIO.java
@@ -1529,7 +1529,7 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
 
     static {
         MethodHandle cat, modify, substr;
-        MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
         try {
             cat = lookup.findVirtual(RubyString.class, "catWithCodeRange", MethodType.methodType(RubyString.class, RubyString.class));
             modify = lookup.findVirtual(RubyString.class, "modifyAndClearCodeRange", MethodType.methodType(void.class));


### PR DESCRIPTION
publicLookup seems to have trouble when there are multiple versions of a signature class in the classloader hierarchy.

Fixes ruby/stringio#112