### PR TITLE
Allow seek when underlying string is frozen

### DIFF
--- a/ext/java/org/jruby/ext/stringio/StringIO.java
+++ b/ext/java/org/jruby/ext/stringio/StringIO.java
@@ -1356,8 +1356,6 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
     }
 
     private RubyFixnum seekCommon(ThreadContext context, int argc, IRubyObject arg0, IRubyObject arg1) {
-        checkModifiable();
-
         Ruby runtime = context.runtime;
 
         IRubyObject whence = context.nil;
@@ -1367,9 +1365,9 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
             whence = arg1;
         }
 
-        checkOpen();
-
         StringIOData ptr = this.getPtr();
+
+        checkOpen();
 
         boolean locked = lock(context, ptr);
         try {

--- a/test/stringio/test_stringio.rb
+++ b/test/stringio/test_stringio.rb
@@ -483,6 +483,11 @@ class TestStringIO < Test::Unit::TestCase
     f.close unless f.closed?
   end
 
+  def test_seek_frozen_string
+    f = StringIO.new(-"1234")
+    assert_equal(0, f.seek(1))
+  end
+
   def test_each_byte
     f = StringIO.new("1234")
     a = []


### PR DESCRIPTION
Fixes #119. Adds a test for this expectation.