### PR TITLE
Small string fixes for encoding compatibility issues

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -29,6 +29,12 @@ jobs:
         git config --global core.eol lf
         git config --global advice.detachedHead 0
     - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: zulu
+        java-version: 21
+      if: >-
+        matrix.ruby == 'jruby-head'
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,6 +30,12 @@ jobs:
         git config --global core.eol lf
         git config --global advice.detachedHead 0
     - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: zulu
+        java-version: 21
+      if: >-
+        matrix.ruby == 'jruby-head'
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/ext/java/org/jruby/ext/stringio/StringIO.java
+++ b/ext/java/org/jruby/ext/stringio/StringIO.java
@@ -1662,7 +1662,7 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
         try {
             RubyString unused = (RubyString) CAT_WITH_CODE_RANGE.invokeExact(myString, str);
         } catch (Throwable t) {
-            throw new RuntimeException(t);
+            Helpers.throwException(t);
         }
     }
 

--- a/ext/java/org/jruby/ext/stringio/StringIO.java
+++ b/ext/java/org/jruby/ext/stringio/StringIO.java
@@ -1696,13 +1696,14 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
         try {
             final Encoding enc = getEncoding();
             if (enc == null) return 0;
-            final Encoding encStr = str.getEncoding();
+            Encoding encStr = str.getEncoding();
             if (enc != encStr && enc != ASCIIEncoding.INSTANCE && enc != USASCIIEncoding.INSTANCE) {
                 RubyString converted = EncodingUtils.strConvEnc(context, str, encStr, enc);
                 if (converted == str && encStr != ASCIIEncoding.INSTANCE && encStr != USASCIIEncoding.INSTANCE) { /* conversion failed */
                     rb_enc_check(context, enc, str);
                 }
                 str = converted;
+                encStr = str.getEncoding();
             }
             final ByteList strByteList = str.getByteList();
             len = str.size();

--- a/ext/java/org/jruby/ext/stringio/StringIO.java
+++ b/ext/java/org/jruby/ext/stringio/StringIO.java
@@ -2201,8 +2201,13 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
     }
 
     private void checkModifiable() {
-        checkFrozen();
-        if (getPtr().string.isFrozen()) throw getRuntime().newIOError("not modifiable string");
+        if (getPtr().string == null || getPtr().string.isNil()) {
+            /* Null device StringIO */
+        } else if (getPtr().string.isFrozen()) {
+            throw getRuntime().newIOError("not modifiable string");
+        } else {
+            getPtr().string.modify();
+        }
     }
 
     private void checkInitialized() {


### PR DESCRIPTION
See ruby/rake#619. The first two fixes here are in service of fixing that failure, but are not the actual bug fix. See jruby/jruby#8711 for the actual fix.

The other two fixes get jruby-head running green in CI.

* Don't re-raise `catString` exceptions as a Java RuntimeException. This caused the ugly output in ruby/rake#619.
* Re-get the encoding when the string to be written in `write` must be converted first, since it may be negotiated to something other than its original encoding.
* Add `setup-java` to `jruby-head` targets to ensure Java 21 is in PATH for JRuby 10.
* Fix modifiable check for null StringIO (from eb4ee4921867c06baf3b7cee95119570953821bb).