### PR TITLE
Fixes for JRuby release build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gemspec
 group :development do
   gem 'rake-compiler'
   gem 'rdoc'
-  gem 'ruby-maven', :platforms => :jruby
   gem 'test-unit'
   gem 'test-unit-ruby-core'
 end


### PR DESCRIPTION
The `rake release` process for releasing fails on JRuby in GHA: https://github.com/ruby/stringio/actions/runs/14066275506/job/39389435498#step:3:278

This PR will attempt to fix that.