### PR TITLE
Do not issue warning when calling set_encoding if string is chilled

### DIFF
--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -1861,7 +1861,7 @@ strio_set_encoding(int argc, VALUE *argv, VALUE self)
     }
     ptr->enc = enc;
     if (!NIL_P(ptr->string) && WRITABLE(self)
-#if RUBY_API_VERSION_MAJOR == 3 || RUBY_API_VERSION_MAJOR >= 4
+#if (RUBY_API_VERSION_MAJOR == 3 && RUBY_API_VERSION_MINOR >= 4) || RUBY_API_VERSION_MAJOR >= 4
             // Do not attempt to modify chilled strings on Ruby 3.4+
             && !FL_TEST_RAW(ptr->string, RUBY_FL_USER2 | RUBY_FL_USER3)
 #endif

--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -20,6 +20,7 @@ STRINGIO_VERSION = "3.1.6";
 #include "ruby.h"
 #include "ruby/io.h"
 #include "ruby/encoding.h"
+#include "ruby/version.h"
 #if defined(HAVE_FCNTL_H) || defined(_WIN32)
 #include <fcntl.h>
 #elif defined(HAVE_SYS_FCNTL_H)
@@ -1859,7 +1860,12 @@ strio_set_encoding(int argc, VALUE *argv, VALUE self)
 	}
     }
     ptr->enc = enc;
-    if (!NIL_P(ptr->string) && WRITABLE(self)) {
+    if (!NIL_P(ptr->string) && WRITABLE(self)
+#if RUBY_API_VERSION_MAJOR == 3 || RUBY_API_VERSION_MAJOR >= 4
+            // Do not attempt to modify chilled strings on Ruby 3.4+
+            && !FL_TEST_RAW(ptr->string, RUBY_FL_USER2 | RUBY_FL_USER3)
+#endif
+            ) {
 	rb_enc_associate(ptr->string, enc);
     }
 

--- a/test/stringio/test_stringio.rb
+++ b/test/stringio/test_stringio.rb
@@ -1057,6 +1057,13 @@ class TestStringIO < Test::Unit::TestCase
       assert_equal("test", io.string)
       assert_same(chilled_string, io.string)
     end
+
+    def test_chilled_string_set_enocoding
+      chilled_string = eval(%{""})
+      io = StringIO.new(chilled_string)
+      assert_warning("") { io.set_encoding(Encoding::BINARY) }
+      assert_same(chilled_string, io.string)
+    end
   end
 
   private


### PR DESCRIPTION
StringIO does not warn for unchilled unfrozen string or for frozen string, so it should not warn for chilled string.