### PR TITLE
Never change the underlying string encoding

### DIFF
--- a/ext/java/org/jruby/ext/stringio/StringIO.java
+++ b/ext/java/org/jruby/ext/stringio/StringIO.java
@@ -421,7 +421,6 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
     public IRubyObject binmode(ThreadContext context) {
         StringIOData ptr = this.getPtr();
         ptr.enc = EncodingUtils.ascii8bitEncoding(context.runtime);
-        if (writable()) ptr.string.setEncoding(ptr.enc);
 
         return this;
     }
@@ -1809,10 +1808,6 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
 
             // in read-only mode, StringIO#set_encoding no longer sets the encoding
             RubyString string = ptr.string;
-            if (string != null && writable() && string.getEncoding() != enc) {
-                string.modify();
-                string.setEncoding(enc);
-            }
         } finally {
             if (locked) unlock(ptr);
         }
@@ -1847,9 +1842,6 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
     private Encoding setEncodingByBOM(ThreadContext context, StringIOData ptr) {
         Encoding enc = detectBOM(context, ptr.string, (ctx, enc2, bomlen) -> {
             ptr.pos = bomlen;
-            if (writable()) {
-                ptr.string.setEncoding(enc2);
-            }
             return enc2;
         });
         ptr.enc = enc;

--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -278,9 +278,6 @@ set_encoding_by_bom(struct StringIO *ptr)
     if (idx) {
 	extenc = rb_enc_from_index(idx);
 	ptr->pos = bomlen;
-	if (ptr->flags & FMODE_WRITABLE) {
-	    rb_enc_associate_index(ptr->string, idx);
-	}
     }
     ptr->enc = extenc;
     return extenc;
@@ -696,9 +693,6 @@ strio_binmode(VALUE self)
     rb_encoding *enc = rb_ascii8bit_encoding();
 
     ptr->enc = enc;
-    if (WRITABLE(self)) {
-	rb_enc_associate(ptr->string, enc);
-    }
     return self;
 }
 
@@ -1859,9 +1853,6 @@ strio_set_encoding(int argc, VALUE *argv, VALUE self)
 	}
     }
     ptr->enc = enc;
-    if (!NIL_P(ptr->string) && WRITABLE(self)) {
-	rb_enc_associate(ptr->string, enc);
-    }
 
     return self;
 }

--- a/test/stringio/test_stringio.rb
+++ b/test/stringio/test_stringio.rb
@@ -304,7 +304,7 @@ class TestStringIO < Test::Unit::TestCase
     f = StringIO.new()
     f.set_encoding("ISO-8859-16:ISO-8859-1")
     assert_equal(Encoding::ISO_8859_16, f.external_encoding)
-    assert_equal(Encoding::ISO_8859_16, f.string.encoding)
+    assert_equal(Encoding::UTF_8, f.string.encoding)
     assert_nil(f.internal_encoding)
   end
 


### PR DESCRIPTION
StringIO should be a view of given source string and set_encoding shouldn't change source encoding.

Similar change for binmode and set_encoding_by_bom.