### PR TITLE
Add a comment to explicit RUBY_FL_USER2 | RUBY_FL_USER3

### DIFF
--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -1868,6 +1868,8 @@ strio_set_encoding(int argc, VALUE *argv, VALUE self)
     if (!NIL_P(ptr->string) && WRITABLE(self)
 #if (RUBY_API_VERSION_MAJOR == 3 && RUBY_API_VERSION_MINOR >= 4) || RUBY_API_VERSION_MAJOR >= 4
             // Do not attempt to modify chilled strings on Ruby 3.4+
+            // RUBY_FL_USER2 == STR_CHILLED_LITERAL
+            // RUBY_FL_USER3 == STR_CHILLED_SYMBOL_TO_S
             && !FL_TEST_RAW(ptr->string, RUBY_FL_USER2 | RUBY_FL_USER3)
 #endif
             ) {


### PR DESCRIPTION
This way when someone removes these flags from Ruby or update them, they'll find this reference when greping.

Followup: https://github.com/ruby/stringio/pull/128

@jeremyevans @kou 