### PR TITLE
Support `Ractor#value`

### DIFF
--- a/test/stringio/test_ractor.rb
+++ b/test/stringio/test_ractor.rb
@@ -17,7 +17,7 @@ class TestStringIOInRactor < Test::Unit::TestCase
         io.puts "def"
         "\0\0\0\0def\n" == io.string
       end
-      puts r.take
+      puts r.value
     end;
   end
 end

--- a/test/stringio/test_ractor.rb
+++ b/test/stringio/test_ractor.rb
@@ -8,6 +8,10 @@ class TestStringIOInRactor < Test::Unit::TestCase
 
   def test_ractor
     assert_in_out_err([], <<-"end;", ["true"], [])
+      class Ractor
+        alias value take
+      end unless Ractor.method_defined? :value # compat with Ruby 3.4 and olders
+
       require "stringio"
       $VERBOSE = nil
       r = Ractor.new do


### PR DESCRIPTION
from https://bugs.ruby-lang.org/issues/21262

We need to alias `Ractor#value` to `Ractor#take` for old versions of Ruby.