### PR TITLE
Add jruby-head to macos CI builds

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,7 +9,7 @@ jobs:
     with:
       engine: cruby
       min_version: 2.7
-      versions: '["debug"]'
+      versions: '["debug", "jruby-head"]'
 
   build:
     needs: ruby-versions


### PR DESCRIPTION
Trying again to add jruby-head to the macos builds in CI. See #116 and jruby/jruby#8642.

ruby-maven and some other parts of the build toolchain have had several changes over the past few months, so the issue may be gone.