### PR TITLE
Revisit jar-dependencies and ruby-maven issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gemspec
 group :development do
   gem 'rake-compiler'
   gem 'rdoc'
-  gem 'ruby-maven', :platforms => :jruby
   gem 'test-unit'
   gem 'test-unit-ruby-core'
   gem 'ruby-core-tasks', github: 'ruby/ruby-core-tasks'


### PR DESCRIPTION
ruby-maven is only used at build time to fetch a Maven install and use it as a tool to build the JRuby extension and jar file. If we have this as a direct development dependency when it is also being installed lazily by gems like psych (transitive dep of rdoc) there are issues with the installed ruby-maven getting overwritten mid- install by bundler.

See ruby/rubygems#9386

This is an attempt to remove the ruby-maven dependency so it does not conflict with the bundling process and we can take a bit more time to figure out the long-term solution.