### PR TITLE
Skip chompped record separator

### DIFF
--- a/ext/java/org/jruby/ext/stringio/StringIO.java
+++ b/ext/java/org/jruby/ext/stringio/StringIO.java
@@ -959,7 +959,8 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
                         p = rsByteList.getBegin();
                         bm_init_skip(skip, rsBytes, p, n);
                         if ((pos2 = bm_search(rsBytes, p, n, stringBytes, s, e - s, skip)) >= 0) {
-                            e = s + pos2 + (chomp ? 0 : n);
+                            e = s + pos2 + n;
+                            if (chomp) w = n;
                         }
                     }
                 }

--- a/ext/stringio/stringio.c
+++ b/ext/stringio/stringio.c
@@ -1447,7 +1447,8 @@ strio_getline(struct getline_arg *arg, struct StringIO *ptr)
 		p = RSTRING_PTR(str);
 		bm_init_skip(skip, p, n);
 		if ((pos = bm_search(p, n, s, e - s, skip)) >= 0) {
-		    e = s + pos + (arg->chomp ? 0 : n);
+		    e = s + pos + n;
+		    if (arg->chomp) w = n;
 		}
 	    }
 	}

--- a/test/stringio/test_stringio.rb
+++ b/test/stringio/test_stringio.rb
@@ -168,6 +168,10 @@ class TestStringIO < Test::Unit::TestCase
     assert_string("", Encoding::UTF_8, StringIO.new("\n").gets(chomp: true))
 
     assert_equal("", StringIO.new("ab").gets("ab", chomp: true))
+
+    sio = StringIO.new("abcde\r\n" "fghij\r\n" + "z"*1024)
+    assert_equal("abcde", sio.gets("\r\n", chomp: true))
+    assert_equal("fghij", sio.gets("\r\n", chomp: true))
   end
 
   def test_gets_chomp_eol


### PR DESCRIPTION
Fix ruby/stringio#218.