### PR TITLE
Use previous RDoc on JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 group :development do
   gem 'rake-compiler'
-  gem 'rdoc'
+  gem 'rdoc', *("< 8.0" if RUBY_ENGINE == "jruby")
   gem 'test-unit'
   gem 'test-unit-ruby-core'
   gem 'ruby-core-tasks', github: 'ruby/ruby-core-tasks'


### PR DESCRIPTION
RDoc 8.0 requires RBS, which provides the C-extension and cannot build on JRuby.